### PR TITLE
Icon caveat.

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -5,7 +5,10 @@ Supercharged by [telescope.nvim](https:/github.com/nvim-telescope/telescope.nvim
 
 https://github.com/dharmx/track.nvim/assets/80379926/3d928ebc-7829-4e84-a81b-9c87a631d5d7
 
-[Read WIKI.](https://github.com/dharmx/track.nvim/wiki)
+
+> [!IMPORTANT]
+>
+> Read the [WIKI](https://github.com/dharmx/track.nvim/wiki)!
 
 ## Installation
 
@@ -90,9 +93,8 @@ M._defaults = {
   bundle_label = true, --  string or, true for automatically fetching bundle_label
   disable_history = true, -- save deleted marks
   maximum_history = 10, -- limit history
-  hooks = { -- main hooks used by Core.select and Core.cycle
+  hooks = { -- main hooks used by Core.select and other Core functions
     on_select = util.open_entry,
-    on_cycle = util.open_entry,
   },
   pad = { -- built-in UI for viewing marks
     icons = {
@@ -329,6 +331,9 @@ HI("TrackBundlesIndex", { foreground = "#54CED6" })
 
 ## Commands
 
+Builtin commands provided by track.nvim. See how to hack and create more commands in the
+[recipes](https://github.com/dharmx/track.nvim/wiki/Recipes) section of the [wiki](https://github.com/dharmx/track.nvim/wiki).
+
 ```vim
 :Mark                               " add current file to marks
 :Mark <URI/PATH>                    " add passed <URI> as mark
@@ -346,7 +351,7 @@ HI("TrackBundlesIndex", { foreground = "#54CED6" })
 :Track bundles                      " open bundles telescope picker
 :Track save                         " save current state to file
 :Track load                         " load saved state for the first time
-:Track loadsave                     " load saved state from a file
+:Track savefile                     " load saved state from a file
 :Track reload                       " load last saved state to cache
 :Track wipe                         " clear caches
 :Track remove                       " rm save file

--- a/lua/telescope/_extensions/track/actions.lua
+++ b/lua/telescope/_extensions/track/actions.lua
@@ -88,6 +88,7 @@ function M.change_bundle_label(buffer)
     input = vim.trim(if_nil(input, ""))
     if input == "" then return end
     root:rename_bundle(bundle, input)
+    require("track.core")(require("track.util").cwd())
     refresh("bundles", pack, -1)
   end)
 end

--- a/lua/track/config.lua
+++ b/lua/track/config.lua
@@ -17,7 +17,6 @@ M._defaults = {
   maximum_history = 10, -- limit history
   hooks = { -- main hooks used by Core.select and Core.cycle
     on_select = util.open_entry,
-    on_cycle = util.open_entry,
   },
   pad = { -- built-in UI for viewing marks
     icons = {


### PR DESCRIPTION
Now a filepath with spaces in between can be saved as is. The matching logic will no more consume the part of the string i.e. upto the first encounter of a space character. There could still be side-effects as a result of this change but, meh...